### PR TITLE
fix: Deprecated events-buffer-scrollback-size

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -1,6 +1,6 @@
 ;;; copilot.el --- An unofficial Copilot plugin for Emacs  -*- lexical-binding:t -*-
 
-;; Package-Requires: ((emacs "27.2") (s "1.12.0") (dash "2.19.1") (editorconfig "0.8.2") (jsonrpc "1.0.14"))
+;; Package-Requires: ((emacs "27.2") (s "1.12.0") (dash "2.19.1") (editorconfig "0.8.2") (jsonrpc "1.0.23"))
 
 ;;; Code:
 (require 'cl-lib)
@@ -139,20 +139,6 @@ Enabling event logging may slightly affect performance."
                                               (funcall ,success-fn result)))
                               ,@args))))
 
-(defun copilot--slot-exists-p (slot-list slot-name)
-  "Return t if SLOT-NAME exists in SLOT-LIST, nil otherwise."
-  (cl-some (lambda (slot) (eq slot-name (cl--slot-descriptor-name slot))) slot-list))
-
-(defun copilot--make-process ()
-  "Make a process for copilot agent."
-  (make-process :name "copilot agent"
-                :command (list copilot-node-executable
-                               (concat copilot--base-dir "/dist/agent.js"))
-                :coding 'utf-8-emacs-unix
-                :connection-type 'pipe
-                :stderr (get-buffer-create "*copilot stderr*")
-                :noquery t))
-
 (defun copilot--start-agent ()
   "Start the copilot agent process in local."
   (if (not (locate-file copilot-node-executable exec-path))
@@ -166,18 +152,17 @@ Enabling event logging may slightly affect performance."
              (user-error "Node 18+ is required but found %s" node-version))
             (t
              (setq copilot--connection
-                   ;; Check for existance of '-events-buffer-config' slot in 'jsonrpc-process-connection' for backwards compatibility
-                   (if (copilot--slot-exists-p (eieio-class-slots 'jsonrpc-process-connection) '-events-buffer-config)
-                       (make-instance 'jsonrpc-process-connection
-                                      :name "copilot"
-                                      :events-buffer-config `(:size ,copilot-log-max)
-                                      :notification-dispatcher #'copilot--handle-notification
-                                      :process (copilot--make-process))
-                     (make-instance 'jsonrpc-process-connection
-                                    :name "copilot"
-                                    :events-buffer-scrollback-size copilot-log-max
-                                    :notification-dispatcher #'copilot--handle-notification
-                                    :process (copilot--make-process))))
+                   (make-instance 'jsonrpc-process-connection
+                                  :name "copilot"
+                                  :events-buffer-config `(:size ,copilot-log-max)
+                                  :notification-dispatcher #'copilot--handle-notification
+                                  :process (make-process :name "copilot agent"
+                                                         :command (list copilot-node-executable
+                                                                        (concat copilot--base-dir "/dist/agent.js"))
+                                                         :coding 'utf-8-emacs-unix
+                                                         :connection-type 'pipe
+                                                         :stderr (get-buffer-create "*copilot stderr*")
+                                                         :noquery t)))
              (message "Copilot agent started.")
              (copilot--request 'initialize '(:capabilities (:workspace (:workspaceFolders t))))
              (copilot--async-request 'setEditorInfo

--- a/copilot.el
+++ b/copilot.el
@@ -141,7 +141,7 @@ Enabling event logging may slightly affect performance."
 
 (defun copilot--slot-exists-p (slot-list slot-name)
   "Return t if SLOT-NAME exists in SLOT-LIST, nil otherwise."
-  (not (null (member slot-name (mapcar #'cl--slot-descriptor-name slot-list)))))
+  (cl-some (lambda (slot) (eq slot-name (cl--slot-descriptor-name slot))) slot-list))
 
 (defun copilot--make-process ()
   "Make a process for copilot agent."

--- a/copilot.el
+++ b/copilot.el
@@ -140,11 +140,8 @@ Enabling event logging may slightly affect performance."
                               ,@args))))
 
 (defun copilot--slot-exists-p (slot-list slot-name)
-  (cl-loop for slot in slot-list
-           when (and (eq 'cl-slot-descriptor (type-of slot))
-                     (eq slot-name (cl-struct-slot-value 'cl-slot-descriptor 'name slot)))
-           return t
-           finally return nil))
+  "Return t if SLOT-NAME exists in SLOT-LIST, nil otherwise."
+  (not (null (member slot-name (mapcar #'cl--slot-descriptor-name slot-list)))))
 
 (defun copilot--make-process ()
   "Make a process for copilot agent."

--- a/copilot.el
+++ b/copilot.el
@@ -1,6 +1,6 @@
 ;;; copilot.el --- An unofficial Copilot plugin for Emacs  -*- lexical-binding:t -*-
 
-;; Package-Requires: ((emacs "27.2") (s "1.12.0") (dash "2.19.1") (editorconfig "0.8.2") (jsonrpc "1.0.22"))
+;; Package-Requires: ((emacs "27.2") (s "1.12.0") (dash "2.19.1") (editorconfig "0.8.2") (jsonrpc "1.0.23"))
 
 ;;; Code:
 (require 'cl-lib)

--- a/copilot.el
+++ b/copilot.el
@@ -1,6 +1,6 @@
 ;;; copilot.el --- An unofficial Copilot plugin for Emacs  -*- lexical-binding:t -*-
 
-;; Package-Requires: ((emacs "27.2") (s "1.12.0") (dash "2.19.1") (editorconfig "0.8.2") (jsonrpc "1.0.14"))
+;; Package-Requires: ((emacs "27.2") (s "1.12.0") (dash "2.19.1") (editorconfig "0.8.2") (jsonrpc "1.0.22"))
 
 ;;; Code:
 (require 'cl-lib)
@@ -154,7 +154,7 @@ Enabling event logging may slightly affect performance."
              (setq copilot--connection
                    (make-instance 'jsonrpc-process-connection
                                   :name "copilot"
-                                  :events-buffer-scrollback-size copilot-log-max
+                                  :events-buffer-config `(:size ,copilot-log-max)
                                   :notification-dispatcher #'copilot--handle-notification
                                   :process (make-process :name "copilot agent"
                                                          :command (list copilot-node-executable


### PR DESCRIPTION
Deprecation was introduced in `jsonrpc 1.0.22` in [this commit](https://github.com/emacs-mirror/emacs/commit/e0b9944b69ff72923c29756fcfcea9528a3f5069).

This PR ~bumps required version to `1.0.22` and~ now uses recommended `:events-buffer-config`.
It's backwards compatible by checking for existence of `-events-buffer-config` slot on `jsonrpc-process-connection`.