### PR TITLE
docs: fix required node version in Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Retired maintainer: [@zerolfx](https://github.com/zerolfx).
 
 0. Ensure your Emacs version is at least 27, and the dependency package `editorconfig` ([melpa](https://melpa.org/#/editorconfig)) is also installed.
 
-1. Install [Node.js](https://nodejs.org/en/download/) v16+. (You can specify the path to `node` executable by setting `copilot-node-executable`.)
+1. Install [Node.js](https://nodejs.org/en/download/) v18+. (You can specify the path to `node` executable by setting `copilot-node-executable`.)
 
 2. Setup `copilot.el` as described in the next section.
 


### PR DESCRIPTION
Update `readme.md` to specify a minimum Node version of `v18` (changed from `v16`)