### PR TITLE
Switch to new repository

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ Add package definition to `~/.doom.d/packages.el`:
 
 ```elisp
 (package! copilot
-  :recipe (:host github :repo "zerolfx/copilot.el" :files ("*.el" "dist")))
+  :recipe (:host github :repo "copilot-emacs/copilot.el" :files ("*.el" "dist")))
 ```
 
 Configure copilot in `~/.doom.d/config.el`:
@@ -94,7 +94,7 @@ dotspacemacs-configuration-layers
 dotspacemacs-additional-packages
  '((copilot :location (recipe
                        :fetcher github
-                       :repo "zerolfx/copilot.el"
+                       :repo "copilot-emacs/copilot.el"
                        :files ("*.el" "dist"))))
 
 ;; ========================
@@ -130,7 +130,7 @@ dotspacemacs-additional-packages
   
 ```elisp
 (use-package copilot
-  :straight (:host github :repo "zerolfx/copilot.el" :files ("dist" "*.el"))
+  :straight (:host github :repo "copilot-emacs/copilot.el" :files ("dist" "*.el"))
   :ensure t)
 ;; you can utilize :map :hook and :config to customize copilot
 ```
@@ -140,7 +140,7 @@ dotspacemacs-additional-packages
 ```elisp
 (use-package copilot
   :quelpa (copilot :fetcher github
-                   :repo "zerolfx/copilot.el"
+                   :repo "copilot-emacs/copilot.el"
                    :branch "main"
                    :files ("dist" "*.el")))
 ;; you can utilize :map :hook and :config to customize copilot


### PR DESCRIPTION
It seems that zerolfx is the old location, and the author switched to `copilot-emacs`. `zerolfx/copilot.el` redirects to `copilot-emacs/copilot.el`.