### PR TITLE
Fix using numbers in copilot-indentation-alist

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -323,8 +323,9 @@ automatically, browse to %s." user-code verification-uri))
                     (setq mode (get mode 'derived-mode-parent))))
         (when mode
           (cl-some (lambda (s)
-                     (when (and (boundp s) (numberp (symbol-value s)))
-                       (symbol-value s)))
+                     (cond ((numberp s) s)
+                           ((and (boundp s) (numberp (symbol-value s))) (symbol-value s))
+                           (t nil)))
                    (alist-get mode copilot-indentation-alist))))
       (progn
         (when (and

--- a/copilot.el
+++ b/copilot.el
@@ -323,9 +323,9 @@ automatically, browse to %s." user-code verification-uri))
                     (setq mode (get mode 'derived-mode-parent))))
         (when mode
           (cl-some (lambda (s)
+                     ;; s can be a symbol or a number.
                      (cond ((numberp s) s)
-                           ((and (boundp s) (numberp (symbol-value s))) (symbol-value s))
-                           (t nil)))
+                           ((and (boundp s) (numberp (symbol-value s))) (symbol-value s))))
                    (alist-get mode copilot-indentation-alist))))
       (progn
         (when (and


### PR DESCRIPTION
As mentioned in #252

Despite using emacs for almost 1.5 decades, my elisp still sucks so feel free to close this and fix it properly.

I've tested this still appears to work with both variable and number values in this alist.