### PR TITLE
fix(copilot.el): Windows' executable path

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -104,7 +104,7 @@ indentation offset."
 
 (defconst copilot--server-executable
   (if (eq system-type 'windows-nt)
-      (f-join copilot-install-dir "node_modules" "copilot-node-server" "copilot"
+      (f-join copilot-install-dir "node_modules" "copilot-node-server"
               "bin" "copilot-node-server")
     (f-join copilot-install-dir "bin" "copilot-node-server"))
   "The dist directory containing agent.js file.")


### PR DESCRIPTION
For https://github.com/copilot-emacs/copilot.el/pull/247#issuecomment-1951473070.