### PR TITLE
Add customization option to disable max-char warning message

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -81,6 +81,11 @@ indentation offset."
   :group 'copilot
   :type 'boolean)
 
+(defcustom copilot-max-char-warning-disable nil
+  "Disable warning when buffer exceeds copilot-max-char."
+  :group 'copilot
+  :type 'boolean)
+
 (defcustom copilot-indentation-alist
   (append '((latex-mode tex-indent-basic)
             (nxml-mode nxml-child-indent)
@@ -401,7 +406,8 @@ automatically, browse to %s." user-code verification-uri))
          (pmax (point-max))
          (pmin (point-min))
          (half-window (/ copilot-max-char 2)))
-    (when (and (>= copilot-max-char 0) (> pmax copilot-max-char))
+    (when (and (>= copilot-max-char 0) (> pmax copilot-max-char)
+               (not copilot-max-char-warning-disable))
       (display-warning '(copilot copilot-exceeds-max-char)
                        (format "%s size exceeds 'copilot-max-char' (%s), copilot completions may not work" (current-buffer) copilot-max-char)))
     (cond


### PR DESCRIPTION
This is just a really simple option I added for my own use, thought other might find it useful. I often open very large files that I don't necessarily care about getting copilot suggestions on and disabling this warning is simpler and more general than setting up emacs configurations to disable the copilot mode for those specific files and file types.

Just set `copilot-max-char-warning-disable` to `t` to disable the warning message that appears when opening a file that exceeds `copilot-max-char`.