### PR TITLE
fix: weird capitalization bug (#300)

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -878,19 +878,20 @@ Arguments BEG, END, and CHARS-REPLACED are metadata for region changed."
          (is-deletion (and is-before-change (not (equal beg end)))))
     (when (or is-insertion is-deletion)
       (save-restriction
-        (widen)
-        (let* ((range-start (list :line (- (line-number-at-pos beg) copilot--line-bias)
-                                  :character (- beg (save-excursion (goto-char beg) (line-beginning-position)))))
-               (range-end (if is-insertion range-start
-                            (list :line (- (line-number-at-pos end) copilot--line-bias)
-                                  :character (- end (save-excursion (goto-char end) (line-beginning-position))))))
-               (text (if is-insertion (buffer-substring-no-properties beg end) ""))
-               (content-changes (vector (list :range (list :start range-start :end range-end)
-                                              :text text))))
-          (cl-incf copilot--doc-version)
-          (copilot--notify 'textDocument/didChange
-                           (list :textDocument (list :uri (copilot--get-uri) :version copilot--doc-version)
-                                 :contentChanges content-changes)))))))
+        (save-match-data
+          (widen)
+          (let* ((range-start (list :line (- (line-number-at-pos beg) copilot--line-bias)
+                                    :character (- beg (save-excursion (goto-char beg) (line-beginning-position)))))
+                 (range-end (if is-insertion range-start
+                              (list :line (- (line-number-at-pos end) copilot--line-bias)
+                                    :character (- end (save-excursion (goto-char end) (line-beginning-position))))))
+                 (text (if is-insertion (buffer-substring-no-properties beg end) ""))
+                 (content-changes (vector (list :range (list :start range-start :end range-end)
+                                                :text text))))
+            (cl-incf copilot--doc-version)
+            (copilot--notify 'textDocument/didChange
+                             (list :textDocument (list :uri (copilot--get-uri) :version copilot--doc-version)
+                                   :contentChanges content-changes))))))))
 
 (defun copilot--on-doc-close (&rest _args)
   "Notify that the document has been closed."


### PR DESCRIPTION
This patch saves the match data inside `copilot--on-doc-change`, fixing a bizarre bug that I encountered only on Windows (#300).  Compare with the second paragraph of https://www.gnu.org/software/emacs/manual/html_node/elisp/Change-Hooks.html.
