### PR TITLE
Add customization to disable max char warning

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -116,6 +116,11 @@ find indentation offset."
   :group 'copilot
   :type 'boolean)
 
+(defcustom copilot-max-char-warning-disable nil
+  "Disable maximum characters warning."
+  :group 'copilot
+  :type 'boolean)
+
 (defcustom copilot-indentation-alist
   (append '((latex-mode tex-indent-basic)
             (nxml-mode nxml-child-indent)
@@ -510,7 +515,7 @@ automatically, browse to %s." user-code verification-uri))
          (pmax (point-max))
          (pmin (point-min))
          (half-window (/ copilot-max-char 2)))
-    (when (and (>= copilot-max-char 0) (> pmax copilot-max-char))
+    (when (and (>= copilot-max-char 0) (> pmax copilot-max-char) (not copilot-max-char-warning-disable))
       (display-warning '(copilot copilot-exceeds-max-char)
                        (format "%s size exceeds 'copilot-max-char' (%s), copilot completions may not work" (current-buffer) copilot-max-char)))
     (cond


### PR DESCRIPTION
Completions work well enough for me even when the file is truncated. Getting a warning every time is therefore unecessary.