### PR TITLE
Verify buffer is present when running the success func

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -281,8 +281,9 @@ SUCCESS-FN is the CALLBACK."
        (jsonrpc-async-request copilot--connection
                               ,method ,params
                               :success-fn (lambda (result)
-                                            (with-current-buffer buf
-                                              (funcall ,success-fn result)))
+                                            (if (buffer-live-p buf)
+                                                (with-current-buffer buf
+                                                  (funcall ,success-fn result))))
                               ,@args))))
 
 (defun copilot--make-connection ()


### PR DESCRIPTION
This is a fix for the issue where copilot is triggered in temporary buffer that could get killed before the success function is called. Eg: Capture, commit-editmsg buffers etc.