### PR TITLE
Indentation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ If pressing tab to complete sometimes doesn't work you might want to bind comple
   (evil-define-key 'insert 'global (kbd "<tab>") 'my/copilot-tab-or-default))
 ```
 
+If you would love to configure indentation here, this is an example config that may work for you:
+```
+(use-package! copilot
+  :hook (prog-mode . copilot-mode)
+  :bind (:map copilot-completion-map
+              ("<tab>" . 'copilot-accept-completion)
+              ("TAB" . 'copilot-accept-completion)
+              ("C-TAB" . 'copilot-accept-completion-by-word)
+              ("C-<tab>" . 'copilot-accept-completion-by-word)
+              ("C-n" . 'copilot-next-completion)
+              ("C-p" . 'copilot-previous-completion))
+
+  :config
+  (add-to-list 'copilot-indentation-alist '(prog-mode . 2))
+  (add-to-list 'copilot-indentation-alist '(org-mode . 2))
+  (add-to-list 'copilot-indentation-alist '(text-mode . 2))
+  (add-to-list 'copilot-indentation-alist '(closure-mode . 2))
+  (add-to-list 'copilot-indentation-alist '(emacs-lisp-mode . 2)))
+```
+
 </details>
 
 ### Example for Spacemacs


### PR DESCRIPTION
It seems like this is not clear on how to configure `copilot-indentation-alist`, and for the new doom emacs users it can be twice as confusing