### PR TITLE
Fix indent inference where lisp-indent-offset goes wrong in lisp-modes

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -117,7 +117,9 @@ find indentation offset."
   :type 'boolean)
 
 (defcustom copilot-indentation-alist
-  (append '((latex-mode tex-indent-basic)
+  (append '((emacs-lisp-mode lisp-indent-offset)
+            (latex-mode tex-indent-basic)
+            (lisp-mode lisp-indent-offset)
             (nxml-mode nxml-child-indent)
             (python-mode python-indent py-indent-offset python-indent-offset)
             (python-ts-mode python-indent py-indent-offset python-indent-offset)
@@ -477,10 +479,8 @@ automatically, browse to %s." user-code verification-uri))
                                 (symbol-value s))))
                        indent-spec))
              ((functionp indent-spec) ; editorconfig 0.11.0+
-              (cl-some (lambda (pair)
-                         (when (numberp (cdr pair))
-                           (cdr pair)))
-                       (funcall indent-spec tab-width)))))))
+              ;; This points to a setter, which do not call
+              nil)))))
       (progn
         (when (and
                (not copilot-indent-offset-warning-disable)


### PR DESCRIPTION
When an indent-spec in `editorconfig-indentation-alist` is a function, it points to an indent setter which should not be called.

This fixes the problem in lisp-modes where `lisp-indent-offset` is unwantedly set to 8.

Closes https://github.com/copilot-emacs/copilot.el/issues/327.