### PR TITLE
ci: Exclude macos tests below 28.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
         - os: macos-latest
           emacs-version: snapshot
           experimental: true
+        exclude:
+          - os: macos-latest
+            emacs-version: 27.2
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Due to https://github.com/purcell/nix-emacs-ci/pull/268.