### PR TITLE
fix: use `standard-indent` instead of `tab-width`

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -484,7 +484,7 @@ automatically, browse to %s." user-code verification-uri))
           (display-warning '(copilot copilot-no-mode-indent)
                            "copilot--infer-indentation-offset found no mode-specific indentation offset.")
           (setq-local copilot--indent-warning-printed-p t))
-        tab-width)))
+        standard-indent)))
 
 (defun copilot--get-relative-path ()
   "Get relative path to current buffer."
@@ -562,7 +562,7 @@ automatically, browse to %s." user-code verification-uri))
   (save-restriction
     (widen)
     (list :version copilot--doc-version
-          :tabSize (copilot--infer-indentation-offset)
+          :tabSize tab-width
           :indentSize (copilot--infer-indentation-offset)
           :insertSpaces (if indent-tabs-mode :json-false t)
           :path (buffer-file-name)


### PR DESCRIPTION
I see the following warnings.

```
Warning: copilot--infer-indentation-offset found no mode-specific indentation offset, using ’tab-width’ instead.  You can suppress this error message by customizing ’copilot-indent-warning-suppress’.
```

Reading the documentation comments for `tab-width` shows that it has no effect if spaces are used for indentation.

```
Documentation
Distance between tab stops (for display of tab characters), in columns.

This controls the width of a TAB character on display.
The value should be a positive integer.
Note that this variable doesn't necessarily affect the size of the
indentation step.  However, if the major mode's indentation facility
inserts one or more TAB characters, this variable will affect the
indentation step as well, even if indent-tabs-mode is non-nil.
```

If tabs are used, the `tab-width` is automatically adjusted, so there seems to be no need to worry about it.

Conversely, `tabSize` is supposed to be the real tab size, not the indentation size, so put the value as it is.
