### PR TITLE
feat(version): Upgrade to Copilot 1.40.0

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -140,9 +140,9 @@ find indentation offset."
   :group 'copilot)
 
 (defvar copilot--server-executable nil
-  "The dist directory containing agent.js file.")
+  "The dist directory containing language-server.js file.")
 
-(defcustom copilot-version "1.27.0"
+(defcustom copilot-version "1.40.0"
   "Copilot version.
 
 The default value is the preferred version and ensures functionality.
@@ -328,6 +328,7 @@ Please upgrade the server via `M-x copilot-reinstall-server`"))
              (setq copilot--connection (copilot--make-connection))
              (message "Copilot agent started.")
              (copilot--request 'initialize '(:capabilities (:workspace (:workspaceFolders t))))
+             (copilot--notify 'initialized '())
              (copilot--async-request 'setEditorInfo
                                      `(:editorInfo (:name "Emacs" :version ,emacs-version)
                                                    :editorPluginInfo (:name "copilot.el" :version ,copilot-version)
@@ -1032,7 +1033,7 @@ in `post-command-hook'."
      possible-paths)))
 
 (defun copilot-server-executable ()
-  "Return the location of the agent.js file."
+  "Return the location of the language-server.js file."
   (if copilot--server-executable
       copilot--server-executable
     (setq copilot--server-executable
@@ -1040,11 +1041,11 @@ in `post-command-hook'."
                  (list
                   (when (eq system-type 'windows-nt)
                     (f-join copilot-install-dir "node_modules"
-                            "copilot-node-server" "copilot" "dist" "agent.js"))
+                            "copilot-node-server" "copilot" "dist" "language-server.js"))
                   (f-join copilot-install-dir "lib" "node_modules"
-                          "copilot-node-server" "copilot" "dist" "agent.js")
+                          "copilot-node-server" "copilot" "dist" "language-server.js")
                   (f-join copilot-install-dir "lib64" "node_modules"
-                          "copilot-node-server" "copilot" "dist" "agent.js"))))
+                          "copilot-node-server" "copilot" "dist" "language-server.js"))))
             (seq-some
              (lambda (path)
                (when (and path (file-exists-p path))


### PR DESCRIPTION
update lsp to 1.40
- added `initialized` notification which required by later lsp server
- updated script entry from `agent.js` to `language-server.js`, assuming not supporting backward compatible since copilot.el enforcing `copilot-node-server`'s version

i am not subscribing copilot and only tested with modded lsp server based on [copilot.vim](https://github.com/github/copilot.vim) so may need someone else help testing it

P.S. 
proposed `copilot-node-server` to add executable entry point https://github.com/jfcherng/copilot-node-server/issues/17
so start from next release the server should be easily started by `npx -y  copilot-node-server@1.40.0 --stdio` therefor can consider simplify the installation and version management later