### PR TITLE
copilot chat poc

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,27 @@ For example:
 (setq copilot-network-proxy '(:host "127.0.0.1" :port 7890))
 ```
 
+### copilot-on-request
+Register a handler to be called when a request of type method is received. Return JSON serializable as result or calling `jsonrpc-error` for errors. [readmore](https://www.gnu.org/software/emacs/manual/html_node/elisp/JSONRPC-Overview.html)
+
+For example:
+```elisp
+; Display desktop notification if emacs is built with d-bus
+(copilot-on-request
+ 'window/showMessageRequest
+ (lambda (msg) (notifications-notify :title "Emacs Copilot" :body (plist-get msg :message))))
+```
+
+### copilot-on-notification
+Register a listener for copilot notifications.
+
+For example:
+```elisp
+(copilot-on-notification
+  'window/logMessage
+  (lambda (msg) (message (plist-get msg :message))
+```
+
 ## Known Issues
 
 ### Wrong Position of Other Completion Popups
@@ -319,7 +340,7 @@ But I decided to allow them to coexist, allowing you to choose a better one at a
 ## Reporting Bugs
 
 + Make sure you have restarted your Emacs (and rebuild the plugin if necessary) after updating the plugin.
-+ Please enable event logging by customize `copilot-log-max` (to e.g. 1000), then paste related logs in the `*copilot events*` and `*copilot stderr*` buffer.
++ Please enable event logging by customize `copilot-log-max` (to e.g. 1000) and enable debug log `(setq copilot-server-args '("--stdio" "--debug"))`, then paste related logs in the `*copilot events*`, `*copilot stderr*` and `*copilot agent log*` buffer.
 + If an exception is thrown, please also paste the stack trace (use `M-x toggle-debug-on-error` to enable stack trace).
 
 ## Roadmap

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -1,0 +1,145 @@
+(require 'json)
+(require 'copilot)
+
+(defun buffer-file-uri ()
+  (interactive)
+  (let ((file-name (buffer-file-name)))
+    (and file-name (concat "file://" file-name))))
+
+
+(defvar buffer-context nil)
+(defvar conversation-id nil)
+(defvar work-done-token -1)
+
+(defconst chat-buffer-name "*Copilot Chat*")
+
+(defun conversation-turn (conv-id chat-msg)
+  (setq work-done-token (1+ work-done-token))
+  (copilot--async-request
+   'conversation/turn
+   (list :workDoneToken work-done-token
+         :conversationId conv-id
+         :message chat-msg)))
+
+
+
+(defun my-chat-send-message (source)
+  "Prompt the user to enter a message and add it to the chat buffer."
+  (let ((chat-msg (read-string "Enter your message: "))
+        (chat-buffer (get-buffer chat-buffer-name)))
+    (setq buffer-context (current-buffer))
+    (message "[buffer-context] %s" buffer-context)
+    (if (and chat-buffer conversation-id)
+        (with-current-buffer chat-buffer
+          (display-buffer chat-buffer)
+          (end-of-buffer)
+          (message "conversation/turn %s" chat-buffer)
+          (insert (concat "User: " chat-msg "\n\n"))
+          (conversation-turn conversation-id chat-msg))
+      (let
+          ((new-chat-buffer (get-buffer-create chat-buffer-name))
+           (document-uri (buffer-file-uri)))
+        (display-buffer new-chat-buffer)
+        (with-current-buffer new-chat-buffer
+          (insert (concat "User: " chat-msg "\n\n"))
+          (message "conversation/create")
+          (message document-uri)
+          (setq work-done-token (1+ work-done-token))
+          (copilot--async-request
+           'conversation/create
+           (list :workDoneToken work-done-token
+                 :turns `[(:request ,chat-msg)]
+                 :capabilities '(:skills [
+                                          "current-editor" ;to inform language server the editor support conversation/context current-editor skill
+                                          ])
+                 :doc (list :uri document-uri)
+                 :source source
+                 )
+           :success-fn (jsonrpc-lambda (&key conversationId turnId agentSlug)(setq conversation-id conversationId))))))))
+
+
+;
+(defun current-editor-skill (conversation-id turn-id)
+  (message "[conversation/context][buffer] %s" buffer-context)
+  (with-current-buffer buffer-context
+    (let ((res `[(:uri ,(buffer-file-uri)
+                       :position (:line ,(line-number-at-pos) :character ,(current-column))
+                       :visibleRange (:start (:line ,(line-number-at-pos (window-start)) :character 1)
+                                             :end (:line ,(1+ (line-number-at-pos (window-end))) :character 1))
+                       ,@(if (region-active-p)
+                             `(:selection (:start (:line ,(line-number-at-pos (region-beginning)) :character 1)
+                                                  :end (:line ,(1+ (line-number-at-pos (region-end))) :character 1))))
+
+                                        ;:openedAt
+                                        ;:activeAt
+                   )
+                 nil]))
+      (message "[conversation/context] %s" res)
+      res)))
+
+(copilot-on-request
+ 'conversation/context
+ (lambda (msg)
+   (message (format "[conversation/context][buffer] %s" buffer-context))
+   (with-current-buffer buffer-context
+     (let ((res (copilot--dbind (:conversationId conversation-id :turnId turn-id :skillId skill-id) msg
+                  (cond
+                   ((string= skill-id "current-editor") (current-editor-skill conversation-id turn-id))
+                   (t '[nil (:code -1 :message "handle skill")])))))
+       (message (json-encode res))
+       res))))
+
+(defun on-progress(msg)
+  (message (format "[$/progress] %s" msg))
+  (copilot--dbind
+      (:token work-done-token
+              :value (:kind kind
+                            :title title
+                            :conversationId conversation-id
+                            :turnId turn-id
+                            :reply reply ; streaming response by lines when kind="report"
+                            :suggestedTitle suggested-title ; receive at the end of turn of "panel" source coversation
+                            :followUp follow-up ; receive at the end of turn of "panel" source coversation
+                            :updatedDocuments updated-documents ; receive at the end of turn of "inline" source coversation
+                            ))
+
+      msg
+    (message "[progress][buffer] %s" (get-buffer chat-buffer-name))
+    (with-current-buffer (get-buffer chat-buffer-name)
+      (end-of-buffer)
+      (message "[progress][kind] %s" kind)
+      (message "[progress][updateDocuments] %s" updated-documents)
+      (cond
+       ((string= kind "begin") (insert "Assistant: "))
+       ((string= kind "end")
+        (when follow-up
+          (message "[Suggested followup]")
+          (insert "Suggested followup: ")
+          (insert follow-up-msg)
+          )
+        (when updated-documents
+          (message "[updated-documents]")
+          (message (format "[updated-documents] %s" updated-documents))
+          (update-documents updated-documents))
+        (insert "\n\n"))
+       (reply (message "[reply] %s" reply) (insert reply))))))
+
+(copilot-on-notification '$/progress (lambda (message) (on-progress message)))
+
+
+(defun update-documents (updated-documents)
+  (seq-do (lambda (doc)
+            (let ((uri (plist-get doc :uri))
+                  (text (plist-get doc :text)))
+              (message "[update-documents] uri: %s" uri)
+              (message "[update-documents] text: %s" text)
+              (with-current-buffer (find-buffer-visiting uri)
+                (delete-region (point-min) (point-max))
+                (insert text))
+              ))
+          updated-documents))
+
+(defun chat-inline () (interactive) (my-chat-send-message "inline"))
+(defun chat-panel () (interactive) (my-chat-send-message "panel"))
+
+(provide 'copilot-chat)

--- a/copilot.el
+++ b/copilot.el
@@ -142,7 +142,7 @@ find indentation offset."
 (defvar copilot--server-executable nil
   "The dist directory containing agent.js file.")
 
-(defcustom copilot-version "1.27.0"
+(defcustom copilot-version "1.40.0"
   "Copilot version.
 
 The default value is the preferred version and ensures functionality.
@@ -329,6 +329,7 @@ Please upgrade the server via `M-x copilot-reinstall-server`"))
              (setq copilot--connection (copilot--make-connection))
              (message "Copilot agent started.")
              (copilot--request 'initialize '(:capabilities (:workspace (:workspaceFolders t))))
+             (copilot--notify 'initialized '())
              (copilot--async-request 'setEditorInfo
                                      `(:editorInfo (:name "Emacs" :version ,emacs-version)
                                                    :editorPluginInfo (:name "copilot.el" :version ,copilot-version)


### PR DESCRIPTION
[chrome-extension-nlipoenfbbikpbjkfpfillcgkoblgpmj-setup-react-html-from-install.webm](https://github.com/user-attachments/assets/67ee7bde-ecd6-48f5-97f1-2a68b5087d79)

just to share some findings about how conversation feature can possibly be implemented for anyone who is interested

language server will behave in 2 different way depends on "source" parameter provided in the `conversation/create` request:
- `panel`: server will analysis the conversation at the end of the response and will suggest title and follow up question
- `inline`: server will try to update the code and notify editor about the new file content, may need to select a region otherwise it's assumed the entire filed is selected and the llm may be confused about what it needs to do

the server use `$/progress` notification to send all kinds of responses
the server send `conversation/context` request to collected chat context, if not handled, server will assume no filed is opened
