### PR TITLE
Adding link to copilot-chat.el project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,11 @@ These projects helped me a lot:
 + https://github.com/cryptobadger/flight-attendant.el
 + https://github.com/github/copilot.vim
 
+## If you want chat with github copilot?
+
+Just like copilot plugin for intellij or vscode?
+
+Please take a look at [copilot-chat.el](https://github.com/chep/copilot-chat.el) 
 
 <!-- Links -->
 


### PR DESCRIPTION
Currently copilot.el don't have chat capability. But github plugin for IntelliJ and VSCode have.

I happen to find the copilot-chat.el project on github. It might be less known than copilot.el. I tried that, it works well. I think it worth to have a link in the README, it is complimentary to copilot.el, and could be useful to people.