### PR TITLE
Address MELPA comments (update summary and use derived-mode-p)

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -1,4 +1,4 @@
-;;; copilot.el --- An unofficial Copilot plugin for Emacs  -*- lexical-binding: t; -*-
+;;; copilot.el --- An unofficial Copilot plugin -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2022-2024  copilot-emacs maintainers
 
@@ -794,7 +794,7 @@ provided."
            (t-completion (funcall (or transform-fn #'identity) completion)))
       (copilot--async-request 'notifyAccepted (list :uuid uuid))
       (copilot-clear-overlay t)
-      (if (eq major-mode 'vterm-mode)
+      (if (derived-mode-p 'vterm-mode)
           (progn
             (vterm-delete-region start end)
             (vterm-insert t-completion))


### PR DESCRIPTION
Hi, I saw there were a few outstanding issues on https://github.com/melpa/melpa/pull/9217 / https://github.com/copilot-emacs/copilot.el/issues/120 and they seemed easy enough to address except for: ```You should depend on (emacs "29.1") if you need `python-ts-mode'.``` which as suggested by the melpa maintainer, seems like a false positive to me.

Hope this is helpful, thanks!