### PR TITLE
Support official Github copilot LSP and allow to install the latest LSP version

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -87,6 +87,16 @@ performance."
   :group 'copilot
   :type 'integer)
 
+(defcustom copilot-server-log-level 0
+  "Log level of the Copilot server.
+0 - no log
+1 - error
+2 - warning
+3 - info
+4 - debug"
+  :group 'copilot
+  :type 'integer)
+
 (defcustom copilot-node-executable (executable-find "node")
   "Node executable path."
   :group 'copilot
@@ -180,6 +190,32 @@ Incremented after each change.")
 
 (defvar copilot--opened-buffers nil
   "List of buffers that have been opened in Copilot.")
+
+(eval-and-compile
+  (defun copilot--transform-pattern (pattern)
+    "Transform PATTERN to (&plist PATTERN) recursively."
+    (cons '&plist
+          (mapcar (lambda (p)
+                    (if (listp p)
+                        (copilot--transform-pattern p)
+                      p))
+                  pattern))))
+
+(defmacro copilot--dbind (pattern source &rest body)
+  "Destructure SOURCE against plist PATTERN and eval BODY."
+  (declare (indent 2))
+  `(-let ((,(copilot--transform-pattern pattern) ,source))
+     ,@body))
+
+(defsubst copilot--log (level format &rest args)
+  "Log message with LEVEL, FORMAT and ARGS."
+  (message "%s: %s" (propertize "Copilot" 'face
+                                (pcase level
+                                  ('error 'error)
+                                  ('warning 'warning)
+                                  ('info 'success)
+                                  (_ 'warning)))
+           (apply #'format format args)))
 
 ;;
 ;; Externals
@@ -289,6 +325,13 @@ SUCCESS-FN is the CALLBACK."
                                                   (funcall ,success-fn result))))
                               ,@args))))
 
+(defun copilot--command ()
+  "Return the command-line to start copilot agent."
+  (append
+   (list copilot-node-executable
+         (copilot-server-executable))
+   copilot-server-args))
+
 (defun copilot--make-connection ()
   "Establish copilot jsonrpc connection."
   (let ((make-fn (apply-partially
@@ -297,10 +340,7 @@ SUCCESS-FN is the CALLBACK."
                   :name "copilot"
                   :notification-dispatcher #'copilot--handle-notification
                   :process (make-process :name "copilot agent"
-                                         :command (append
-                                                   (list copilot-node-executable
-                                                         (copilot-server-executable))
-                                                   copilot-server-args)
+                                         :command (copilot--command)
                                          :coding 'utf-8-emacs-unix
                                          :connection-type 'pipe
                                          :stderr (get-buffer-create "*copilot stderr*")
@@ -332,33 +372,19 @@ You can change the installed version with `M-x copilot-reinstall-server` or remo
              (user-error "Node 18+ is required but found %s" node-version))
             (t
              (setq copilot--connection (copilot--make-connection))
-             (message "Copilot agent started.")
-             (copilot--request 'initialize '(:capabilities (:workspace (:workspaceFolders t))))
+             (copilot--log 'info "Copilot agent started.")
+             (copilot--request 'initialize `( :capabilities (:workspace (:workspaceFolders t))
+                                              :processId ,(emacs-pid)))
+             (copilot--notify 'initialized '())
              (copilot--async-request 'setEditorInfo
-                                     `(:editorInfo (:name "Emacs" :version ,emacs-version)
-                                                   :editorPluginInfo (:name "copilot.el" :version ,copilot-version)
-                                                   ,@(when copilot-network-proxy
-                                                       `(:networkProxy ,copilot-network-proxy))))))))))
+                                     `( :editorInfo (:name "Emacs" :version ,emacs-version)
+                                        :editorPluginInfo (:name "copilot.el" :version ,copilot-version)
+                                        ,@(when copilot-network-proxy
+                                            `(:networkProxy ,copilot-network-proxy))))))))))
 
 ;;
 ;; login / logout
 ;;
-
-(eval-and-compile
-  (defun copilot--transform-pattern (pattern)
-    "Transform PATTERN to (&plist PATTERN) recursively."
-    (cons '&plist
-          (mapcar (lambda (p)
-                    (if (listp p)
-                        (copilot--transform-pattern p)
-                      p))
-                  pattern))))
-
-(defmacro copilot--dbind (pattern source &rest body)
-  "Destructure SOURCE against plist PATTERN and eval BODY."
-  (declare (indent 2))
-  `(-let ((,(copilot--transform-pattern pattern) ,source))
-     ,@body))
 
 (defun copilot-login ()
   "Login to Copilot."
@@ -378,19 +404,19 @@ automatically, browse to %s." user-code verification-uri))
           (read-from-minibuffer "Press ENTER if you finish authorizing."))
       (read-from-minibuffer (format "First copy your one-time code: %s. Press ENTER to continue." user-code))
       (read-from-minibuffer (format "Please open %s in your browser. Press ENTER if you finish authorizing." verification-uri)))
-    (message "Verifying...")
+    (copilot--log 'info "Verifying...")
     (condition-case err
         (copilot--request 'signInConfirm (list :userCode user-code))
       (jsonrpc-error
        (user-error "Authentication failure: %s" (alist-get 'jsonrpc-error-message (cddr err)))))
     (copilot--dbind (:user) (copilot--request 'checkStatus '(:dummy "checkStatus"))
-      (message "Authenticated as GitHub user %s." user))))
+      (copilot--log 'info "Authenticated as GitHub user %s." user))))
 
 (defun copilot-logout ()
   "Logout from Copilot."
   (interactive)
   (copilot--request 'signOut '(:dummy "signOut"))
-  (message "Logged out."))
+  (copilot--log 'warning "Logged out."))
 
 ;;
 ;; diagnose
@@ -400,7 +426,7 @@ automatically, browse to %s." user-code verification-uri))
   "Restart and diagnose copilot."
   (interactive)
   (when copilot--connection
-    (jsonrpc-shutdown copilot--connection)
+    (jsonrpc-shutdown copilot--connection 'kill)
     (setq copilot--connection nil))
   (setq copilot--opened-buffers nil)
   ;; We are going to send a test request for the current buffer so we have to activate the mode
@@ -419,11 +445,11 @@ automatically, browse to %s." user-code verification-uri))
                                            :languageId "text"
                                            :position (:line 0 :character 0)))
                           :success-fn (lambda (_)
-                                        (message "Copilot OK."))
+                                        (copilot--log 'info "Copilot OK."))
                           :error-fn (lambda (err)
-                                      (message "Copilot error: %S" err))
+                                      (copilot--log 'error "%S" err))
                           :timeout-fn (lambda ()
-                                        (message "Copilot agent timeout."))))
+                                        (copilot--log 'warning "Copilot agent timeout."))))
 
 ;;
 ;; Auto completion
@@ -605,9 +631,9 @@ automatically, browse to %s." user-code verification-uri))
                                              :key (lambda (x) (plist-get x :text))
                                              :test #'s-equals-p)))
       (cond ((seq-empty-p completions)
-             (message "No completion is available."))
+             (copilot--log 'warning "No completion is available."))
             ((= (length completions) 1)
-             (message "Only one completion is available."))
+             (copilot--log 'warning "Only one completion is available."))
             (t (let ((idx (mod (+ copilot--completion-idx direction)
                                (length completions))))
                  (setq copilot--completion-idx idx)
@@ -667,9 +693,9 @@ automatically, browse to %s." user-code verification-uri))
                                 :panelId (generate-new-buffer-name "copilot-panel"))
                           :success-fn callback
                           :error-fn (lambda (err)
-                                      (message "Copilot error: %S" err))
+                                      (copilot--log 'error "%S" err))
                           :timeout-fn (lambda ()
-                                        (message "Copilot agent timeout."))))
+                                        (copilot--log 'warning "Copilot agent timeout."))))
 
 
 (defun copilot-panel-complete ()
@@ -681,7 +707,7 @@ automatically, browse to %s." user-code verification-uri))
 
   (copilot--get-panel-completions
    (jsonrpc-lambda (&key solutionCountTarget)
-     (message "Copilot: Synthesizing %d solutions..." solutionCountTarget)))
+     (copilot--log 'info "Synthesizing %d solutions..." solutionCountTarget)))
   (with-current-buffer (get-buffer-create "*copilot-panel*")
     (org-mode)
     (erase-buffer)))
@@ -942,7 +968,7 @@ Arguments BEG, END, and CHARS-REPLACED are metadata for region changed."
          (if completion
              (copilot--show-completion completion)
            (when called-interactively
-             (message "No completion is available."))))))))
+             (copilot--log 'warning "No completion is available."))))))))
 
 ;;
 ;; minor mode
@@ -1110,7 +1136,7 @@ in `post-command-hook'."
          npm-binary
          "-g" "--prefix" copilot-install-dir
          "install" (format "%s@%s" copilot-server-package-name copilot-version)))
-    (message "Unable to install %s via `npm' because it is not present" copilot-server-package-name)
+    (copilot--log 'warning "Unable to install %s via `npm' because it is not present" copilot-server-package-name)
     nil))
 
 ;;;###autoload
@@ -1127,7 +1153,7 @@ in `post-command-hook'."
   (unless (file-directory-p copilot-install-dir)
     (user-error "Couldn't find %s directory" copilot-install-dir))
   (delete-directory copilot-install-dir 'recursive)
-  (message "Server `%s' uninstalled." (file-name-nondirectory (directory-file-name copilot-install-dir))))
+  (copilot--log 'warning "Server `%s' uninstalled." (file-name-nondirectory (directory-file-name copilot-install-dir))))
 
 (provide 'copilot)
 ;;; copilot.el ends here


### PR DESCRIPTION
Support official Github copilot LSP and allow to install the latest LSP version via `copilot-version = nil`.