### PR TITLE
copilot-server-executable: support executable from path

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -1072,7 +1072,7 @@ in `post-command-hook'."
          (f-exists? copilot-server-executable))
     copilot-server-executable)
    ((executable-find copilot-server-executable t)
-    copilot-server-executable)
+    (executable-find copilot-server-executable t))
    (t
     (let ((path (executable-find
                  (f-join copilot-install-dir


### PR DESCRIPTION
Since inside `copilot--start-agent` it does a `file-exists-p`-check we need to return the full path.