### PR TITLE
Let "copilot-server-executable" return absolute path

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -1071,8 +1071,7 @@ in `post-command-hook'."
    ((and (f-absolute? copilot-server-executable)
          (f-exists? copilot-server-executable))
     copilot-server-executable)
-   ((executable-find copilot-server-executable t)
-    copilot-server-executable)
+   ((executable-find copilot-server-executable t))
    (t
     (let ((path (executable-find
                  (f-join copilot-install-dir


### PR DESCRIPTION
As "copilot--start-agent" uses "(file-exists-p (copilot-server-executable))", it will fail if the path is not absolute.

I manually installed copilot server without using "copilot-install-server", without this fixing, it reports error "Server is not installed, please install via `M-x copilot-install-server`". 