### PR TITLE
Allow users to specify `settings` of Copilot LSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,11 @@ You can configure the underlying LSP settings by changing `copilot-lsp-settings`
 Here we set the GitHub Enterprise server to `https://example2.ghe.com`, exchange the URL with your own server.
 
 ```elisp
-(setq copilot-lsp-settings '(:github-enterprise (:uri "https://example2.ghe.com")))
+(setopt copilot-lsp-settings '(:github-enterprise (:uri "https://example2.ghe.com"))) ;; allows changing the value without restarting the LSP
+(setq copilot-lsp-settings '(:github-enterprise (:uri "https://example2.ghe.com"))) ;; alternatively
 ```
 
-You might have to restart the LSP (`M-x copilot-diagnose`) when changing the value, depending on the method of setting the variable. When logging in, the URL for the authentication flow should be the same as the one set in `copilot-lsp-settings`.
+You have to restart the LSP (`M-x copilot-diagnose`) when using `setq` to change the value. When logging in, the URL for the authentication flow should be the same as the one set in `copilot-lsp-settings`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,18 @@ Use tab to accept completions (you may also want to bind `copilot-accept-complet
 (define-key copilot-completion-map (kbd "TAB") 'copilot-accept-completion)
 ```
 
+#### 4. Configure LSP Settings
+
+You can configure the underlying LSP settings by changing `copilot-lsp-settings`. The complete list of available options can be found [here](https://github.com/github/copilot-language-server-release?tab=readme-ov-file#configuration-management).
+
+Here we set the GitHub Enterprise server to `https://example2.ghe.com`, exchange the URL with your own server.
+
+```elisp
+(setq copilot-lsp-settings '(:github-enterprise (:uri "https://example2.ghe.com")))
+```
+
+You might have to restart the LSP (`M-x copilot-diagnose`) when changing the value, depending on the method of setting the variable. When logging in, the URL for the authentication flow should be the same as the one set in `copilot-lsp-settings`.
+
 </details>
 
 ### Programming language detection

--- a/copilot.el
+++ b/copilot.el
@@ -177,7 +177,7 @@ You may adjust this variable at your own risk."
   :group 'copilot
   :package-version '(copilot . "0.1"))
 
-(defun copilot--lsp-configuration-changed (symbol value)
+(defun copilot--lsp-settings-changed (symbol value)
   "Restart the Copilot LSP due to SYMBOL changed to VALUE.
 
 This function will be called by the customization framework when the
@@ -212,7 +212,7 @@ For example to use GitHub Enterprise use the following configuration:
  '(:github-enterprise (:uri \"https://example.ghe.com\"))
 
 Exchange the URI with the correct URI of your organization."
-  :set #'copilot--lsp-configuration-changed
+  :set #'copilot--lsp-settings-changed
   :type 'sexp
   :group 'copilot
   :package-version '(copilot . "0.2"))


### PR DESCRIPTION
## Feature
This allows users to set the `settings` (https://github.com/github/copilot-language-server-release?tab=readme-ov-file#configuration-management) for the Copilot LSP. VSCode stores this in `settings.json`? Having this feature allows users to login into GitHub Enterprise instances. Without this it is not possible. You can also disable telemetry with this.

## How To Test
Testing this without a GHE instance is tricky but doable.

1. Start Emacs and evaluate this PR.
2. Log out of your current session (`M-x copilot-logout`).
3.  Use `eval-last-sexp (C-x C-e)` to step through the following snippets

```elisp
(copilot--start-agent)
(copilot-login)
;; you should be able to login, everything works fine (abort login C-g)
(setopt
 copilot-lsp-settings
 '(:github-enterprise (:uri "https://example2.ghe.com")))
(copilot-login)
;; there should be an error, the instance does not exist, the error code shows the url
```
Another test can be:
```elisp
(setq copilot-log-max 2000)
(copilot--start-agent)
(switch-to-buffer-other-window "*copilot events*")
(setopt
 copilot-lsp-settings
 '(:github-enterprise (:uri "https://example2.ghe.com")))
;; you will see in the log that the telemetry tries to fetch from the instance (with an error of course)
(setopt
 copilot-lsp-settings
 '(:github-enterprise (:uri "https://example2.ghe.com")
   :telemetry (:telemetryLevel "all")))
;; now the previous telemetry error is gone
```
