### PR TITLE
Trim external deps

### DIFF
--- a/Eask
+++ b/Eask
@@ -13,8 +13,6 @@
 (source 'melpa)
 
 (depends-on "emacs" "27.2")
-(depends-on "s")
-(depends-on "dash")
 (depends-on "editorconfig")
 (depends-on "jsonrpc")
 (depends-on "f")

--- a/README.md
+++ b/README.md
@@ -183,8 +183,6 @@ Use `:map`, `:hook`, and `:config` to customize `copilot.el` via `use-package`.
 
 Please make sure you have these dependencies installed (available in ELPA/MELPA):
 
-+ `dash`
-+ `s`
 + `editorconfig`
 + `f`
 

--- a/copilot-balancer.el
+++ b/copilot-balancer.el
@@ -31,8 +31,7 @@
 (require 'cl-lib)
 (require 'pcase)
 (require 'rx)
-
-(require 'dash)
+(require 'subr-x)
 
 (defvar copilot-balancer-lisp-modes '( emacs-lisp-mode
                                        lisp-mode
@@ -311,8 +310,9 @@ character).")
        (completion-pairs (copilot-balancer-extract-pairs trimmed-completion))
 
        (`(,meta-prefix-pairs . ,in-string)
-        (-> (append prefix-pairs completion-pairs)
-            (copilot-balancer-collapse-matching-pairs nil)))
+        (thread-first
+          (append prefix-pairs completion-pairs)
+          (copilot-balancer-collapse-matching-pairs nil)))
 
        (infix-string-fixup-needed
         (and (= start end)
@@ -340,8 +340,9 @@ character).")
           (list trimmed-completion meta-prefix-pairs in-string)))
 
        (`(,suffix-pairs . _)
-        (-> (copilot-balancer-extract-pairs suffix)
-            (copilot-balancer-collapse-matching-pairs in-string)))
+        (thread-first
+          (copilot-balancer-extract-pairs suffix)
+          (copilot-balancer-collapse-matching-pairs in-string)))
        (reversed-suffix-pairs (reverse suffix-pairs))
        (flipped-suffix-pairs (mapcar #'copilot-balancer-get-other-pair
                                      reversed-suffix-pairs))

--- a/copilot.el
+++ b/copilot.el
@@ -41,7 +41,7 @@
 (require 'compile)
 (require 'json)
 (require 'jsonrpc)
-(require 'subr-x.el)
+(require 'subr-x)
 
 (require 'f)
 (require 'editorconfig)

--- a/copilot.el
+++ b/copilot.el
@@ -1076,8 +1076,8 @@ in `post-command-hook'."
 (defun copilot-server-executable ()
   "Return the location of the `copilot-server-executable' file."
   (cond
-   ((and (f-absolute? copilot-server-executable)
-         (f-exists? copilot-server-executable))
+   ((and (file-name-absolute-p copilot-server-executable)
+         (file-exists-p copilot-server-executable))
     copilot-server-executable)
    ((executable-find copilot-server-executable t))
    (t
@@ -1087,7 +1087,7 @@ in `post-command-hook'."
                              (t "bin"))
                        copilot-server-executable)
                  t)))
-      (unless (and path (f-exists? path))
+      (unless (and path (file-exists-p path))
         (error "The package %s is not installed.  Unable to find %s"
                copilot-server-package-name path))
       path))))


### PR DESCRIPTION
The package uses a few external deps that are not really needed on modern Emacs:

- `s.el` is easily replaced with built-in functions
- `dash` is easily replaced with the built-in `seq`
- `f.el` can also be replaced easily with built-in functions

When it comes to external deps, less is always more. :-) 