### PR TITLE
Tag a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - "v*"  # Trigger when a version tag is pushed (e.g., v1.0.0)
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Create GitHub Release with Auto-Generated Notes
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ github.ref_name }}
+          name: copilot.el ${{ github.ref_name }}
+          prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-alpha') || contains(github.ref, '-beta') }}
+          generateReleaseNotes: true  # Auto-generate release notes based on PRs and commits
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022-2024  copilot-emacs maintainers
+Copyright (c) 2022-2025  copilot-emacs maintainers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/copilot-balancer.el
+++ b/copilot-balancer.el
@@ -1,6 +1,6 @@
 ;;; copilot-balancer.el --- Parentheses balancer for Lisps  -*- lexical-binding:t -*-
 
-;; Copyright (C) 2022-2024  copilot-emacs maintainers
+;; Copyright (C) 2022-2025  copilot-emacs maintainers
 
 ;; The MIT License (MIT)
 

--- a/copilot.el
+++ b/copilot.el
@@ -1,6 +1,6 @@
 ;;; copilot.el --- An unofficial Copilot plugin -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2022-2024  copilot-emacs maintainers
+;; Copyright (C) 2022-2025  copilot-emacs maintainers
 
 ;; Author: zerol <z@zerol.me>
 ;; Maintainer: Emil van der Westhuizen

--- a/copilot.el
+++ b/copilot.el
@@ -8,7 +8,7 @@
 ;;             Rakotomandimby Mihamina <mihamina.rakotomandimby@rktmb.org>
 ;; URL: https://github.com/copilot-emacs/copilot.el
 ;; Package-Requires: ((emacs "27.2") (editorconfig "0.8.2") (jsonrpc "1.0.14") (f "0.20.0"))
-;; Version: 0.0.1
+;; Version: 0.1.0
 ;; Keywords: convenience copilot
 
 ;; The MIT License (MIT)


### PR DESCRIPTION
@zerolfx would it be possible to merge this and push a "v0.1.0" tag afterwards?

It will address #353 and will make it easier to distribute "stable" releases to our users.

P.S. If I seem reliable enough you can consider making me a co-maintainer, so I can deal with such tasks myself as well. 