### PR TITLE
Fix undefined function call

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -192,7 +192,7 @@ will not be called."
       ;; to nil would require to send the value '(:github-enterprise (:uri nil))
       ;; to the server. Otherwise, the value is ignored, since sending nil is
       ;; not enough.
-      (copilot--start-agent))))
+      (copilot--start-server))))
 
 (defcustom copilot-lsp-settings nil
   "Settings for the Copilot LSP server.


### PR DESCRIPTION
Naming was changed in 463ed62b7b00729118e0ab9f1588eea6f6b8e18d. And bb517382be5d0dc673f9381e9c2a0956dfc9dc45 calls the wrong server start function. We have to use `copilot--server-start` instead of `copilot--agent-start`.

### Testing
If you have the current version installed, then evaluating the following snippet should throw an error.

```elisp
(setopt copilot-lsp-settings nil)
```

With the fix this should not happen.