### PR TITLE
Preserve manually typed trailing whitespace when accepting completions

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -982,12 +982,11 @@ provided."
            (completion-start (overlay-get copilot--overlay 'completion-start)))
       ;; If there is extra indentation before the point, delete it and shift the completion
       (when (and (< completion-start (point))
-                 (string-blank-p (s-trim (buffer-substring-no-properties completion-start (point))))
-                 ;; Only remove indentation is completion-start is not at the beginning of the line
-                 (save-excursion
-                   (goto-char completion-start)
-                   (beginning-of-line)
-                   (not (= (point) completion-start))))
+                 ;; Region we are about to delete contains only blanks …
+                 (string-blank-p (buffer-substring-no-properties completion-start (point)))
+                 ;; … *and* everything from BOL to completion-start is blank
+                 ;; as well — i.e. we are really inside the leading indentation.
+                 (string-blank-p (buffer-substring-no-properties (line-beginning-position) completion-start)))
         (setq start completion-start)
         (setq end (- end (- (point) completion-start)))
         (delete-region completion-start (point)))


### PR DESCRIPTION
This pull request fixes a bug where `copilot.el` would incorrectly delete manually typed whitespace inside a line when accepting a completion.

**Problem**

When I typed a partial line ending with a space (e.g., "Finish this "), accepting a Copilot suggestion would incorrectly delete the trailing space, resulting in malformed text (e.g., "Finish thissentence.").

The cause was overly aggressive deletion logic in `copilot-accept-completion`, which treated any blank characters between `completion-start` and `point` as indentation, regardless of context.

**Solution**

Tighten the condition that decides when to remove pre-existing whitespace:

Now, pre-existing whitespace is only deleted if everything from the beginning of the line up to completion-start is also blank, ensuring we are truly inside the line’s indentation area.

If the user has typed a meaningful space within a sentence, it will no longer be deleted.

This ensures that we are only deleting spaces if the entire prefix from line start is blank, preserving user-intended formatting inside the line.